### PR TITLE
[2020-08-17] Create Event API_02

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,17 @@
             <artifactId>spring-restdocs-mockmvc</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!--
+        maven Central URL : https://mvnrepository.com/artifact/org.modelmapper/modelmapper
+        [용석:2020-08-17] : 입력값 제한을 위해 생성한 객체와 처리가 값 할당이 필요한 항목을 포함한 객체 mapping을 위한 modelMapper dependency 추가
+        -->
+        <dependency>
+            <groupId>org.modelmapper</groupId>
+            <artifactId>modelmapper</artifactId>
+            <version>2.3.8</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/io/api/event/EventApplication.java
+++ b/src/main/java/io/api/event/EventApplication.java
@@ -1,7 +1,9 @@
 package io.api.event;
 
+import org.modelmapper.ModelMapper;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class EventApplication {
@@ -10,4 +12,8 @@ public class EventApplication {
         SpringApplication.run(EventApplication.class, args);
     }
 
+    @Bean
+    public ModelMapper modelMapper(){
+        return new ModelMapper();
+    }
 }

--- a/src/main/java/io/api/event/controller/EventController.java
+++ b/src/main/java/io/api/event/controller/EventController.java
@@ -1,11 +1,11 @@
 package io.api.event.controller;
 
-import io.api.event.entity.event.Event;
+import io.api.event.domain.dto.event.EventDto;
+import io.api.event.domain.entity.event.Event;
 import io.api.event.repository.EventRepository;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.modelmapper.ModelMapper;
 import org.springframework.hateoas.MediaTypes;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -48,14 +48,35 @@ public class EventController {
 
     /* 생성자를 이용한 Bean 주입 -> @Autowired annotaion을 이용하여 Bean을 주입하거나 생성자를 이용하여 bean을 주입*/
     private final EventRepository eventRepository;
-    public EventController(EventRepository eventRepository){
-        this.eventRepository = eventRepository;
-    }
+//    public EventController(EventRepository eventRepository){
+//        this.eventRepository = eventRepository;
+//    }
 
     @PostMapping(value = "/event03")
     ResponseEntity createEvent03(@RequestBody Event event){
+        log.info("event03 start");
         Event createdEvent = this.eventRepository.save(event);
         URI createdUri = linkTo(methodOn(EventController.class).createEvent03(event)).slash(createdEvent.getId()).toUri();
         return ResponseEntity.created(createdUri).body(event);
+    }
+
+    private final ModelMapper modelMapper;
+
+    public EventController(EventRepository eventRepository, ModelMapper modelMapper){
+        this.eventRepository = eventRepository;
+        this.modelMapper = modelMapper;
+    }
+
+    /* ModelMapper를 이용한 javaBean mapping */
+    @PostMapping(value = "/event04")
+    ResponseEntity createEvent04(@RequestBody EventDto eventDto){
+        log.info("event04 start");
+        //EventDto객체를 이용하여 입력 파라미터를 수신 후 Event객체의 setter를이용하여 값을 옮기는 방법을 대체 할 modelMapper
+        Event event = modelMapper.map(eventDto, Event.class);
+        log.info(event.toString());
+        Event createdEvent = eventRepository.save(event);
+        log.info(createdEvent.toString());
+        URI createdUri = linkTo(methodOn(EventController.class).createEvent04(eventDto)).slash(createdEvent.getId()).toUri();
+        return ResponseEntity.created(createdUri).body(createdEvent);
     }
 }

--- a/src/main/java/io/api/event/domain/dto/event/EventDto.java
+++ b/src/main/java/io/api/event/domain/dto/event/EventDto.java
@@ -1,0 +1,26 @@
+package io.api.event.domain.dto.event;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@EqualsAndHashCode(of = "{id}")
+@ToString
+// 입력값을 제한하기 위해 파라미터로 수신할 객체
+public class EventDto {
+    private String name;
+    private String description;
+    private LocalDateTime beginEnrollmentDateTime;
+    private LocalDateTime closeEnrollmentDateTime;
+    private LocalDateTime beginEventDateTime;
+    private LocalDateTime endEventDateTime;
+    private String location; // (optional) 온라인/오프라인 구분 필드
+    private int basePrice; // (optional)
+    private int maxPrice; // (optional)
+    private int limitOfEnrollment;
+}

--- a/src/main/java/io/api/event/domain/entity/event/Event.java
+++ b/src/main/java/io/api/event/domain/entity/event/Event.java
@@ -1,4 +1,4 @@
-package io.api.event.entity.event;
+package io.api.event.domain.entity.event;
 
 import lombok.*;
 
@@ -11,9 +11,8 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 @EqualsAndHashCode(of = "id")
+@ToString
 @Entity
-
-
 public class Event {
 
     //SpringBoot 2.1 부터는 JPA 3.2를 지원
@@ -39,6 +38,7 @@ public class Event {
     private boolean offline;
     private boolean free;
 
+    //default value로 DRAFT를 지정
     @Enumerated(EnumType.STRING)
-    private EventStatus eventStatus;
+    private EventStatus eventStatus = EventStatus.DRAFT;
 }

--- a/src/main/java/io/api/event/domain/entity/event/EventStatus.java
+++ b/src/main/java/io/api/event/domain/entity/event/EventStatus.java
@@ -1,4 +1,4 @@
-package io.api.event.entity.event;
+package io.api.event.domain.entity.event;
 
 public enum EventStatus {
     DRAFT, PUBLISHED, BEGAN_ENROLLMEND, CLOSED_ENROLLMENT, STARTED,  ENDED;

--- a/src/main/java/io/api/event/repository/EventRepository.java
+++ b/src/main/java/io/api/event/repository/EventRepository.java
@@ -1,6 +1,6 @@
 package io.api.event.repository;
 
-import io.api.event.entity.event.Event;
+import io.api.event.domain.entity.event.Event;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EventRepository extends JpaRepository<Event, Integer> {

--- a/src/test/java/io/api/event/domain/entity/event/EventTest.java
+++ b/src/test/java/io/api/event/domain/entity/event/EventTest.java
@@ -1,4 +1,4 @@
-package io.api.event.entity.event;
+package io.api.event.domain.entity.event;
 
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
 - 입력값을 통해 결정되어야 하는 항목의 입력값 제한을 위한 EventDto 생성
 - ModelMapper를 이용하여 입력값을 제한한 객체와 로직처리를 위한 객체 Mapping : (pom.xml -> ModelMapper Dependency 추가)
 - ModelMapper 공용 사용을 위한 Bean등록 : EventApplication
 - EventStatus 기본값 DRAFT 지정
 - 실제 로직 Test를 위해 @WebMvcTest를 이용한 slice Test가 아닌 @SpringBootTest를 이용한 Integration Test 진행