### PR TITLE
[2020-08-27] Create Event API_07 : Set Link Info to API ResponseBody by Spring HATEOAS

### DIFF
--- a/src/main/java/io/api/event/domain/dto/event/EventResource.java
+++ b/src/main/java/io/api/event/domain/dto/event/EventResource.java
@@ -1,0 +1,37 @@
+package io.api.event.domain.dto.event;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import io.api.event.domain.entity.event.Event;
+import org.springframework.hateoas.RepresentationModel;
+
+/**
+ * SpringBoot 및 HATEOAS 버전 업그레이드에 따른 클래스명 변경
+ *  - ResourceSupport changed to RepresentationModel
+ *  - Resource changed to EntityModel
+ *  - Resources changed to CollectionModel
+ *  - PagedResources changed to PagedModel
+ *  - ResourceAssembler changed to RepresentationModelAssembler
+ * official docs URL : https://docs.spring.io/spring-hateoas/docs/current/reference/html/
+ * 참고 URL : https://stackoverflow.com/questions/25352764/hateoas-methods-not-found
+ * */
+/**
+ * Spring에서 ObjectMapper가 BeanSerializr를 이용하여 Object를 Json으로 Serialization할 때
+ * BeanSerializr는 기본적으로 Compose객체(다른 필드들을 포함하는 객체ex:vo,dto등의 domain객체)명으로 하위 필드들을 감싸서
+ * 직렬화 하므로 compose객체의 class명으로 감싸진 형태의 json형태로 직렬화 한다.
+ *
+ * 이슈 : 응답내 json항목에 class명을 제외하기 위해서 @JsonUnwrapped를 사용해서 직렬화시 객체의 class명을 제외한다.
+ *
+ * */
+public class EventResource extends RepresentationModel {
+
+    @JsonUnwrapped
+    private Event event;
+
+    public EventResource(Event event) {
+        this.event = event;
+    }
+
+    public Event getEvent() {
+        return event;
+    }
+}

--- a/src/main/java/io/api/event/domain/dto/event/EventResourceWithEntityModel.java
+++ b/src/main/java/io/api/event/domain/dto/event/EventResourceWithEntityModel.java
@@ -1,0 +1,41 @@
+package io.api.event.domain.dto.event;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import io.api.event.controller.EventController;
+import io.api.event.domain.entity.event.Event;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.Link;
+
+import static org.springframework.hateoas.server.mvc.ControllerLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.ControllerLinkBuilder.methodOn;
+
+/**
+ * SpringBoot 및 HATEOAS 버전 업그레이드에 따른 클래스명 변경
+ *  - ResourceSupport changed to RepresentationModel
+ *  - Resource changed to EntityModel
+ *  - Resources changed to CollectionModel
+ *  - PagedResources changed to PagedModel
+ *  - ResourceAssembler changed to RepresentationModelAssembler
+ * official docs URL : https://docs.spring.io/spring-hateoas/docs/current/reference/html/
+ * 참고 URL : https://stackoverflow.com/questions/25352764/hateoas-methods-not-found
+ * */
+
+/**
+ * {@link EventResource} Class의 코드량을 줄이기 위한 Refactor Class
+ * {@link org.springframework.hateoas.RepresentationModel}내부에
+ * @JsonUnwrapped가 이미 적용되어 구현된 EntityModel<T> Method를 이용하여 개발자가 코드로 명시하지 않고
+ * 코드를 줄이면서 같은효과를 얻는다.
+ * */
+public class EventResourceWithEntityModel extends EntityModel<Event> {
+
+    public EventResourceWithEntityModel(Event event, Link... links) {
+        super(event, links);
+
+        /**
+         * String으로 Url을 명시하는 경우 Controller 혹은 method의 mapping정보가 변경될 경우 typeSafe하지 않으므로
+         * Spring HATEOAS의 linkto()를 사용하여 mapping정보 변경에도 typeSafe하게 작성
+         * */
+//        add(new Link("http://localhost:8080/api/event/" + event.getId()).withSelfRel();
+        add(linkTo(methodOn(EventController.class).createEvent09(null, null)).withSelfRel());
+    }
+}

--- a/src/test/java/io/api/event/controller/EventControllerTest.java
+++ b/src/test/java/io/api/event/controller/EventControllerTest.java
@@ -324,4 +324,76 @@ class EventControllerTest {
                 .andExpect(jsonPath("eventStatus").value(EventStatus.DRAFT.name()))
         ;
     }
+
+    @Test
+    @TestDescription("이벤트 생성 API 호출 후 성공 응답에 HATEOAS의 RepresentationModel을 이용한 profile관련 링크 유무 확인")
+    public void createEventAPI_Check_API_link_info_by_HATEOAS_RepresentationModel() throws Exception {
+        Event event = Event.builder()
+                .name("루나소프트 생활 체육회")
+                .description("제 2회 루나 배 풋살 대회")
+                .beginEnrollmentDateTime(LocalDateTime.of(2020, 8, 06, 9, 30 ))
+                .closeEnrollmentDateTime(LocalDateTime.of(2020, 8, 07, 9, 30 ))
+                .beginEventDateTime(LocalDateTime.of(2020, 8, 13, 19, 00))
+                .endEventDateTime(LocalDateTime.of(2020, 8, 13, 22, 00))
+                .basePrice(100)
+                .maxPrice(200)
+                .limitOfEnrollment(0)
+                .location("서울시 강남구 일원동 마루공원 풋살장 1면")
+                .build();
+
+        mockMvc.perform(post("/api/event08")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaTypes.HAL_JSON)
+                .characterEncoding(StandardCharsets.UTF_8.name())
+                .content(objectMapper.writeValueAsString(event))
+        )
+        .andDo(print())
+        .andExpect(status().isCreated())
+        .andExpect(header().exists(HttpHeaders.LOCATION))
+        .andExpect(header().exists(HttpHeaders.CONTENT_TYPE))
+        .andExpect(jsonPath("id").exists())
+        .andExpect(jsonPath("free").value(false))
+        .andExpect(jsonPath("offline").value(true))
+        .andExpect(jsonPath("eventStatus").value(EventStatus.DRAFT.name()))
+        .andExpect(jsonPath("_links.self").exists())
+        .andExpect(jsonPath("_links.query-events").exists())
+        .andExpect(jsonPath("_links.update-event").exists())
+        ;
+    }
+
+    @Test
+    @TestDescription("이벤트 생성 API 호출 후 성공 응답에 HATEOAS의 EntityModel을 이용한 profile관련 링크 유무 확인")
+    public void createEventAPI_Check_API_link_info_by_HATEOAS_EntityModel() throws Exception {
+        Event event = Event.builder()
+                .name("루나소프트 생활 체육회")
+                .description("제 2회 루나 배 풋살 대회")
+                .beginEnrollmentDateTime(LocalDateTime.of(2020, 8, 06, 9, 30 ))
+                .closeEnrollmentDateTime(LocalDateTime.of(2020, 8, 07, 9, 30 ))
+                .beginEventDateTime(LocalDateTime.of(2020, 8, 13, 19, 00))
+                .endEventDateTime(LocalDateTime.of(2020, 8, 13, 22, 00))
+                .basePrice(100)
+                .maxPrice(200)
+                .limitOfEnrollment(0)
+                .location("서울시 강남구 일원동 마루공원 풋살장 1면")
+                .build();
+
+        mockMvc.perform(post("/api/event09")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaTypes.HAL_JSON)
+                .characterEncoding(StandardCharsets.UTF_8.name())
+                .content(objectMapper.writeValueAsString(event))
+        )
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(header().exists(HttpHeaders.LOCATION))
+                .andExpect(header().exists(HttpHeaders.CONTENT_TYPE))
+                .andExpect(jsonPath("id").exists())
+                .andExpect(jsonPath("free").value(false))
+                .andExpect(jsonPath("offline").value(true))
+                .andExpect(jsonPath("eventStatus").value(EventStatus.DRAFT.name()))
+                .andExpect(jsonPath("_links.self").exists())
+                .andExpect(jsonPath("_links.query-events").exists())
+                .andExpect(jsonPath("_links.update-event").exists())
+        ;
+    }
 }


### PR DESCRIPTION
 - Spring HATEOAS를 이용한 API 응답내 전이 가능한 Link 정보 설정
 - Spring HATEOAS의 RepresentationModel, EntityModel을 활용하여 응답 객체에 Link 항목 추가 처리