### PR TITLE
[2020-08-27] Create Event API_08 : Add API DOCS Info to TC by Spring REST DOCS

### DIFF
--- a/src/main/java/io/api/event/config/CustomMediaTypes.java
+++ b/src/main/java/io/api/event/config/CustomMediaTypes.java
@@ -1,0 +1,7 @@
+package io.api.event.config;
+
+public class CustomMediaTypes {
+
+    public static final String HAL_JSON_UTF8_VALUE = "application/hal+json;charset=UTF-8";
+
+}

--- a/src/main/java/io/api/event/controller/EventController.java
+++ b/src/main/java/io/api/event/controller/EventController.java
@@ -1,5 +1,6 @@
 package io.api.event.controller;
 
+import io.api.event.config.CustomMediaTypes;
 import io.api.event.domain.dto.event.EventDto;
 import io.api.event.domain.dto.event.EventResource;
 import io.api.event.domain.dto.event.EventResourceWithEntityModel;
@@ -8,7 +9,6 @@ import io.api.event.repository.EventRepository;
 import io.api.event.util.event.EventValidator;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
-import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.server.mvc.ControllerLinkBuilder;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -24,7 +24,7 @@ import java.net.URI;
 import static org.springframework.hateoas.server.mvc.ControllerLinkBuilder.linkTo;
 import static org.springframework.hateoas.server.mvc.ControllerLinkBuilder.methodOn;
 
-@RequestMapping(value = "/api", produces = MediaTypes.HAL_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
+@RequestMapping(value = "/api", produces = CustomMediaTypes.HAL_JSON_UTF8_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
 @RestController
 @Slf4j
 public class EventController {
@@ -185,7 +185,7 @@ public class EventController {
 
         EventResource eventResource = new EventResource(event);
         eventResource.add(selfLinkBuilder.withSelfRel());
-        eventResource.add(selfLinkBuilder.slash(createdEvent.getId()).withRel("query-events"));
+        eventResource.add(selfLinkBuilder.slash(createdEvent.getId()).withRel("query-event"));
         eventResource.add(selfLinkBuilder.slash(createdEvent.getId()).withRel("update-event"));
 
         return ResponseEntity.created(createdUri).body(eventResource);
@@ -215,7 +215,7 @@ public class EventController {
         URI createdUri = selfLinkBuilder.toUri();
 
         EventResourceWithEntityModel eventResourceWithEntityModel = new EventResourceWithEntityModel(event);
-        eventResourceWithEntityModel.add(selfLinkBuilder.slash(createdEvent.getId()).withRel("query-events"));
+        eventResourceWithEntityModel.add(selfLinkBuilder.slash(createdEvent.getId()).withRel("query-event"));
         eventResourceWithEntityModel.add(selfLinkBuilder.slash(createdEvent.getId()).withRel("update-event"));
 
         return ResponseEntity.created(createdUri).body(eventResourceWithEntityModel);

--- a/src/test/java/io/api/event/config/RestDocsConfiguration.java
+++ b/src/test/java/io/api/event/config/RestDocsConfiguration.java
@@ -1,0 +1,28 @@
+package io.api.event.config;
+
+import org.springframework.boot.test.autoconfigure.restdocs.RestDocsMockMvcConfigurationCustomizer;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+
+@TestConfiguration
+public class RestDocsConfiguration {
+
+    @Bean
+    public RestDocsMockMvcConfigurationCustomizer restDocsMockMvcConfigurationCustomizer(){
+//        return new RestDocsMockMvcConfigurationCustomizer() {
+//            @OverrideE
+//            public void customize(MockMvcRestDocumentationConfigurer configurer) {
+//                configurer.operationPreprocessors()
+//                        .withRequestDefaults(prettyPrint())
+//                        .withResponseDefaults(prettyPrint());
+//            }
+//        };
+
+        // 위 코드 구문을 java 8 lamda로 변환
+        return configurer -> configurer.operationPreprocessors()
+                .withRequestDefaults(prettyPrint())
+                .withResponseDefaults(prettyPrint());
+    }
+}

--- a/src/test/java/io/api/event/controller/EventControllerTest.java
+++ b/src/test/java/io/api/event/controller/EventControllerTest.java
@@ -1,21 +1,19 @@
 package io.api.event.controller;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.api.event.config.RestDocsConfiguration;
 import io.api.event.domain.dto.event.EventDto;
 import io.api.event.domain.entity.event.Event;
 import io.api.event.domain.entity.event.EventStatus;
-import io.api.event.repository.EventRepository;
 import io.api.event.util.common.TestDescription;
 import lombok.extern.slf4j.Slf4j;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -24,6 +22,11 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
+import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.links;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -38,6 +41,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 //@WebMvcTest
 @SpringBootTest
 @AutoConfigureMockMvc // @SpringBootTest annotation을 이용한 통합테스트 진행 시 해당 TC내에서 MockMvc를 주입하기위한 annotation
+@AutoConfigureRestDocs
+@Import(RestDocsConfiguration.class)
 class EventControllerTest {
 
     /** SpringMVC Test 핵심 클래스
@@ -356,7 +361,7 @@ class EventControllerTest {
         .andExpect(jsonPath("offline").value(true))
         .andExpect(jsonPath("eventStatus").value(EventStatus.DRAFT.name()))
         .andExpect(jsonPath("_links.self").exists())
-        .andExpect(jsonPath("_links.query-events").exists())
+        .andExpect(jsonPath("_links.query-event").exists())
         .andExpect(jsonPath("_links.update-event").exists())
         ;
     }
@@ -392,8 +397,122 @@ class EventControllerTest {
                 .andExpect(jsonPath("offline").value(true))
                 .andExpect(jsonPath("eventStatus").value(EventStatus.DRAFT.name()))
                 .andExpect(jsonPath("_links.self").exists())
-                .andExpect(jsonPath("_links.query-events").exists())
+                .andExpect(jsonPath("_links.query-event").exists())
                 .andExpect(jsonPath("_links.update-event").exists())
         ;
     }
+
+    @Test
+    @TestDescription("Spring REST DOCS를 이용한 Mocking TC로 API Docs 생성 유무 테스트")
+    public void create_API_Docs_By_SpringRestDocs_() throws Exception {
+        EventDto eventDto = EventDto.builder()
+                .name("루나소프트 생활 체육회")
+                .description("제 2회 루나 배 풋살 대회")
+                .beginEnrollmentDateTime(LocalDateTime.of(2020, 8, 06, 9, 30 ))
+                .closeEnrollmentDateTime(LocalDateTime.of(2020, 8, 07, 9, 30 ))
+                .beginEventDateTime(LocalDateTime.of(2020, 8, 13, 19, 00))
+                .endEventDateTime(LocalDateTime.of(2020, 8, 13, 22, 00))
+                .basePrice(100)
+                .maxPrice(200)
+                .limitOfEnrollment(0)
+                .location("서울시 강남구 일원동 마루공원 풋살장 1면")
+                .build();
+
+        mockMvc.perform(post("/api/event09")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaTypes.HAL_JSON)
+                .characterEncoding(StandardCharsets.UTF_8.name())
+                .content(objectMapper.writeValueAsString(eventDto))
+            )
+            .andDo(print())
+            .andExpect(status().isCreated())
+            .andExpect(header().exists(HttpHeaders.LOCATION))
+            .andExpect(header().exists(HttpHeaders.CONTENT_TYPE))
+            .andExpect(jsonPath("id").exists())
+            .andExpect(jsonPath("free").value(false))
+            .andExpect(jsonPath("offline").value(true))
+            .andExpect(jsonPath("eventStatus").value(EventStatus.DRAFT.name()))
+            .andExpect(jsonPath("_links.self").exists())
+            .andExpect(jsonPath("_links.query-event").exists())
+            .andExpect(jsonPath("_links.update-event").exists())
+            /** write Docs snippets
+             * - Request Header/Body and each Field 문서화
+             * - Response Header/Body and each Field 문서화
+             * - Link info 문서화
+             *  - self
+             *  - query-events
+             *  - update-event
+             *  - profile
+             * */
+            .andDo(document("EventAPI DOCS",
+                    links(
+                            linkWithRel("self").description("link to self"),
+                            linkWithRel("query-event").description("link to query ans event"),
+                            linkWithRel("update-event").description("link to update an existing event")
+                    ),
+                    requestHeaders(
+                            headerWithName(HttpHeaders.ACCEPT).description("accept header"),
+                            headerWithName(HttpHeaders.CONTENT_TYPE).description("content type haeder")
+                    ),
+                    requestFields(
+                            fieldWithPath("name").description("Name of new event"),
+                            fieldWithPath("description").description("Description of new event"),
+                            fieldWithPath("beginEnrollmentDateTime").description("Date time of begin enrollment of new event"),
+                            fieldWithPath("closeEnrollmentDateTime").description("Date time of close enrollment of new event"),
+                            fieldWithPath("beginEventDateTime").description("Date time of begin of new event"),
+                            fieldWithPath("endEventDateTime").description("Date time of close of new event"),
+                            fieldWithPath("location").description("Location of new event"),
+                            fieldWithPath("basePrice").description("Base Price of new event"),
+                            fieldWithPath("maxPrice").description("MaxPrice of new event"),
+                            fieldWithPath("limitOfEnrollment").description("Limit of enrollment of new event")
+                    ),
+                    responseHeaders(
+                            headerWithName(HttpHeaders.LOCATION).description("Location header"),
+                            headerWithName(HttpHeaders.CONTENT_TYPE).description("Response content type")
+                    ),
+                    responseFields(
+                            fieldWithPath("id").description("identifier of new event"),
+                            fieldWithPath("name").description("Name of new event"),
+                            fieldWithPath("description").description("Description of new event"),
+                            fieldWithPath("beginEnrollmentDateTime").description("Date time of begin enrollment of new event"),
+                            fieldWithPath("closeEnrollmentDateTime").description("Date time of close enrollment of new event"),
+                            fieldWithPath("beginEventDateTime").description("Date time of begin of new event"),
+                            fieldWithPath("endEventDateTime").description("Date time of close of new event"),
+                            fieldWithPath("location").description("Location of new event"),
+                            fieldWithPath("basePrice").description("Base Price of new event"),
+                            fieldWithPath("maxPrice").description("MaxPrice of new event"),
+                            fieldWithPath("limitOfEnrollment").description("Limit of enrollment of new event"),
+                            fieldWithPath("offline").description("it tells if this event is free"),
+                            fieldWithPath("free").description("it tells if this event is offline"),
+                            fieldWithPath("eventStatus").description("eventStatus of new event"),
+                            fieldWithPath("_links.self.href").description("link to self"),
+                            fieldWithPath("_links.query-event.href").description("link to query an event"),
+                            fieldWithPath("_links.update-event.href").description("link to update an existing event")
+                    )
+                    /** relaxedResponseFields
+                     * Spring RestDocs는 Test 수행 결과로 수신한 ResponseBody의 각 항목 전체를 문서로 기술 하도록 강제 하고 있다.
+                     * 원하는 필드만 문서로 기술해야 하는 경우 responseFields가 아닌 relaxedResponseFields를 사용한다.
+                     * - 장점 : 문서 일부분만 테스트 할 수 있다.
+                     * - 단점 : 정확한 문서를 생성하지 못한다.
+                     * */
+//                    relaxedResponseFields(
+//                            fieldWithPath("id").description("identifier of new event"),
+//                            fieldWithPath("name").description("Name of new event"),
+//                            fieldWithPath("description").description("Description of new event"),
+//                            fieldWithPath("beginEnrollmentDateTime").description("Date time of begin enrollment of new event"),
+//                            fieldWithPath("closeEnrollmentDateTime").description("Date time of close enrollment of new event"),
+//                            fieldWithPath("beginEventDateTime").description("Date time of begin of new event"),
+//                            fieldWithPath("endEventDateTime").description("Date time of close of new event"),
+//                            fieldWithPath("location").description("Location of new event"),
+//                            fieldWithPath("basePrice").description("Base Price of new event"),
+//                            fieldWithPath("maxPrice").description("MaxPrice of new event"),
+//                            fieldWithPath("limitOfEnrollment").description("Limit of enrollment of new event"),
+//                            fieldWithPath("offline").description("it tells if this event is free"),
+//                            fieldWithPath("free").description("it tells if this event is offline"),
+//                            fieldWithPath("eventStatus").description("eventStatus of new event")
+//                    )
+            ))
+            ;
+    }
+
 }


### PR DESCRIPTION
 - Spring REST DOCS를 통해 Test Case 결과값을 이용한 Docs Snippets 생성
 - Test Case의 andDo() 구문에 links, requestHeaders, requestFields responseHeaders, responseFields 항목을 작성
   - Request Header/Body and each Field 문서화
   - Response Header/Body and each Field 문서화
   - Link info 문서화
 - application/hal+json;charset=UTF-8 응답 처리를 위한 CustomMediaTypes 생성 및 HAL_JSON_UTF8_VALUE constants 추가