### PR TITLE
[2020-09-20] Event API_21 : Add Spring Security Resource Server

### DIFF
--- a/src/main/java/io/api/event/config/ResourceServerConfig.java
+++ b/src/main/java/io/api/event/config/ResourceServerConfig.java
@@ -1,0 +1,39 @@
+package io.api.event.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableResourceServer;
+import org.springframework.security.oauth2.config.annotation.web.configuration.ResourceServerConfigurerAdapter;
+import org.springframework.security.oauth2.config.annotation.web.configurers.ResourceServerSecurityConfigurer;
+import org.springframework.security.oauth2.provider.error.OAuth2AccessDeniedHandler;
+
+@Configuration
+@EnableResourceServer
+public class ResourceServerConfig extends ResourceServerConfigurerAdapter {
+
+    @Override
+    public void configure(ResourceServerSecurityConfigurer resources) throws Exception {
+        resources.resourceId("event");
+    }
+
+    @Override
+    public void configure(HttpSecurity http) throws Exception {
+        http
+            // 익명 사용자 허용
+            .anonymous()
+                .and()
+            // 인증 허용 요청 정의
+            .authorizeRequests()
+                // /api/** 이하의 GET 요청을 인증 없이 허용
+                .mvcMatchers(HttpMethod.GET, "/api/**")
+                    .anonymous()
+                // 이외에 다른 요청은 인증 처리
+                .anyRequest()
+                    .authenticated()
+                .and()
+            // access_token정보가 없는 요청의 Exception 처리
+            .exceptionHandling()
+                .accessDeniedHandler(new OAuth2AccessDeniedHandler());
+    }
+}

--- a/src/main/java/io/api/event/config/SecurityConfig.java
+++ b/src/main/java/io/api/event/config/SecurityConfig.java
@@ -61,14 +61,15 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http
-            // 익명사용자를 허용
+            // 익명 사용자 허용
             .anonymous()
                 .and()
-            // form 인증을 사용
+            // form 인증 사용
             .formLogin()
                 .and()
-            // 인증 없이 허용할 요청을 정의
+            // 인증 허용 요청 정의
             .authorizeRequests()
+                // /api/** 이하의 GET 요청을 인증 없이 허용
                 .mvcMatchers(HttpMethod.GET, "/api/**")
                     .anonymous()
             // 이외에 다른 요청은 인증 처리


### PR DESCRIPTION
 - Spring Security의 ResourceServerConfigurerAdapter를 이용한 리소스 서버 구현
 - EventControllerTest 파일 내 Get요청을 제외한 Test Case에 인증 정보 추가
   - AuthServerConfig 설정을 이용해 생성한 access_token 항목을 header에 추가
 - jUnit5 @BeforeEach를 이용한 각 Test Case 실행전 Repository Clear